### PR TITLE
Be able to disable Cilium and use MetalLB plus the default CNI instead.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,15 @@ The environment assumes we're interconnecting two clusters from different networ
 
 > This is a work in progress
 
-The following deploys a traditional Istio with proxies (in other words, it assumes `ISTIO_PROFILE=default`):
+The following deploys a traditional Istio with proxies (in other words, it assumes `ISTIO_PROFILE=default`). 
+
+However, if you want to use ambient mode, run the following *before* the above commands:
+```bash
+export ISTIO_PROFILE=ambient
+export CILIUM_ENABLED=false
+```
+
+> DNS doesn't work well when having Cilium and Istio in Ambient mode. Disabling Cilium uses default Kind CNI and MetalLB for LoadBalancers.
 
 ```bash
 # Create the root and intermediate CAs for the backplane
@@ -30,11 +38,6 @@ The following deploys a traditional Istio with proxies (in other words, it assum
 ./deploy-west.sh
 # Update the remote secrets to interconnect the clusters
 ./deploy-secrets.sh
-```
-
-If you want to use ambient mode, run the following *before* the above commands:
-```bash
-export ISTIO_PROFILE=ambient
 ```
 
 # Verify

--- a/deploy-east.sh
+++ b/deploy-east.sh
@@ -4,10 +4,10 @@ set -euo pipefail
 trap 's=$?; echo >&2 "$0: Error on line "$LINENO": $BASH_COMMAND"; exit $s' ERR
 
 CONTEXT=${CONTEXT-east} # Unique on each cluster
-SUBNET=${SUBNET-248} # For Cilium L2/LB (must be unique across all clusters)
+SUBNET=${SUBNET-248} # Last octet from the /29 CIDR subnet to use for LoadBalancer IPs
 WORKERS=${WORKERS-1}
 CLUSTER_ID=${CLUSTER_ID-1} # Unique on each cluster
-POD_CIDR=${POD_CIDR-10.11.0.0/16} # Must be under 10.0.0.0/8 for Cilium ipv4NativeRoutingCIDR
+POD_CIDR=${POD_CIDR-10.11.0.0/16} # Pod subnet for the cluster (when using Cilium, it must be under 10.0.0.0/8 for ipv4NativeRoutingCIDR)
 SVC_CIDR=${SVC_CIDR-172.21.0.0/16} # Must differ from Kind's Docker Network
 
 echo "Deploying Kubernetes"

--- a/deploy-west.sh
+++ b/deploy-west.sh
@@ -4,10 +4,10 @@ set -euo pipefail
 trap 's=$?; echo >&2 "$0: Error on line "$LINENO": $BASH_COMMAND"; exit $s' ERR
 
 CONTEXT=${CONTEXT-west} # Unique on each cluster
-SUBNET=${SUBNET-240} # For Cilium L2/LB (must be unique across all clusters)
+SUBNET=${SUBNET-240} # Last octet from the /29 CIDR subnet to use for LoadBalancer IPs
 WORKERS=${WORKERS-1}
 CLUSTER_ID=${CLUSTER_ID-2} # Unique on each cluster
-POD_CIDR=${POD_CIDR-10.12.0.0/16} # Must be under 10.0.0.0/8 for Cilium ipv4NativeRoutingCIDR
+POD_CIDR=${POD_CIDR-10.12.0.0/16} # Pod subnet for the cluster (when using Cilium, it must be under 10.0.0.0/8 for ipv4NativeRoutingCIDR)
 SVC_CIDR=${SVC_CIDR-172.22.0.0/16} # Must differ from Kind's Docker Network
 
 echo "Deploying Kubernetes"


### PR DESCRIPTION
I noticed that when deploying Multi-Cluster with Istio Ambient and Cilium, DNS doesn't work properly, preventing the resolution of service FQDNs. For that reason, I added a way to disable Cilium, keep Kind's default CNI, and use MetalLB for LoadBalancer services (required for Istio east-west gateways).