### PR TITLE
Re-instantiate Cilium. It does work with Istio Ambient.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,17 +17,17 @@ The environment assumes we're interconnecting two clusters from different networ
 
 # Run
 
-> This is a work in progress
+By default, the script deploys a traditional Istio with proxies (in other words, it assumes `ISTIO_PROFILE=default`). 
 
-The following deploys a traditional Istio with proxies (in other words, it assumes `ISTIO_PROFILE=default`). 
-
-However, if you want to use ambient mode, run the following *before* the above commands:
+If you want to use ambient mode, run the following command:
 ```bash
 export ISTIO_PROFILE=ambient
-export CILIUM_ENABLED=false
 ```
 
-> DNS doesn't work well when having Cilium and Istio in Ambient mode. Disabling Cilium uses default Kind CNI and MetalLB for LoadBalancers.
+If for some reason you want to disable Cilium and use Kind's default CNI plus MetalLB, run the following command:
+```bash
+export CILIUM_ENABLED=false
+```
 
 ```bash
 # Create the root and intermediate CAs for the backplane
@@ -111,8 +111,8 @@ If you're using Ambient mode, run the following instead:
 ❯ istioctl zc workload --workload-namespace sample
 NAMESPACE POD NAME                                                                                                               ADDRESS     NODE        WAYPOINT PROTOCOL
 sample    east/SplitHorizonWorkload/istio-system/istio-eastwestgateway/192.168.97.248/sample/helloworld.sample.svc.cluster.local                         None     HBONE
-sample    helloworld-v2-6746879bdd-jmwtw                                                                                         10.12.1.173 west-worker None     HBONE
-sample    sleep-868c754c4b-22w5t                                                                                                 10.12.1.249 west-worker None     HBONE
+sample    helloworld-v2-6746879bdd-g4n4z                                                                                         10.12.1.240 west-worker None     HBONE
+sample    sleep-868c754c4b-pqjc2                                                                                                 10.12.1.202 west-worker None     HBONE
 ```
 
 For more details:
@@ -124,11 +124,11 @@ For more details:
         "5000": 5000
       service: ""
       workloadUid: east/SplitHorizonWorkload/istio-system/istio-eastwestgateway/192.168.97.248/sample/helloworld.sample.svc.cluster.local
-    west//Pod/sample/helloworld-v2-6746879bdd-jmwtw:
+    west//Pod/sample/helloworld-v2-6746879bdd-g4n4z:
       port:
         "5000": 5000
       service: ""
-      workloadUid: west//Pod/sample/helloworld-v2-6746879bdd-jmwtw
+      workloadUid: west//Pod/sample/helloworld-v2-6746879bdd-g4n4z
   hostname: helloworld.sample.svc.cluster.local
   ipFamilies: IPv4
   name: helloworld
@@ -138,14 +138,14 @@ For more details:
   subjectAltNames:
   - spiffe://cluster.local/ns/sample/sa/default
   vips:
-  - east/172.21.230.204
-  - west/172.22.46.175
+  - east/172.21.242.207
+  - west/172.22.160.179
 - endpoints:
-    west//Pod/sample/sleep-868c754c4b-22w5t:
+    west//Pod/sample/sleep-868c754c4b-pqjc2:
       port:
         "80": 80
       service: ""
-      workloadUid: west//Pod/sample/sleep-868c754c4b-22w5t
+      workloadUid: west//Pod/sample/sleep-868c754c4b-pqjc2
   hostname: sleep.sample.svc.cluster.local
   ipFamilies: IPv4
   name: sleep
@@ -153,8 +153,8 @@ For more details:
   ports:
     "80": 80
   vips:
-  - west/172.22.159.217
-```
+  - west/172.22.86.36
+  ```
 
 To test connectivity, run the following multiple times:
 

--- a/deploy-kind.sh
+++ b/deploy-kind.sh
@@ -3,9 +3,6 @@
 # Source: https://github.com/agalue/LGTM-PoC/blob/main/deploy-kind.sh
 # Modified to support both Cilium and MetalLB configurations for Istio multi-cluster setups
 # Use CILIUM_ENABLED=false for MetalLB (better for Istio ambient mode multi-cluster)
-#
-# IMPORTANT: Confirmed that Cilium conflicts with Istio 1.27.0 in ambient mode causing DNS issues
-# in multi-cluster setups. MetalLB resolves these DNS resolution problems between clusters.
 
 set -euo pipefail
 trap 's=$?; echo >&2 "$0: Error on line "$LINENO": $BASH_COMMAND"; exit $s' ERR
@@ -65,9 +62,6 @@ networking:
   podSubnet: ${POD_CIDR}
   serviceSubnet: ${SVC_CIDR}
 EOF
-
-# Wait for the cluster to be ready
-kubectl wait --for=condition=Ready nodes --all --timeout=300s
 
 # Calculate LoadBalancer CIDR (common for both Cilium and MetalLB)
 NETWORK=$(docker network inspect kind \


### PR DESCRIPTION
I don't recall the exact reason I mentioned that Istio Ambient and Cilium have issues with DNS. I retested everything, and it works as intended.

In any case, you can create the Kind clusters with and without Cilium, providing more options to the lab.